### PR TITLE
Escape HTML entities

### DIFF
--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "he": {
+      "version": "0.5.0"
+    }
+  }
+}

--- a/meta-extractor.js
+++ b/meta-extractor.js
@@ -10,8 +10,7 @@ if (Meteor.isClient) {
 }
 
 if (Meteor.isServer) {
-  // Server side example (sync):
-  // console.log(extractMeta('http://efounders.co'));
+  var he = Npm.require('he');
 
   extractMeta = function (params) {
     var html, match;
@@ -52,10 +51,18 @@ if (Meteor.isServer) {
         meta_tag_regex.lastIndex++;
       }
 
-      if(match[1] === 'description' || match[1] === 'og:description' || match[1] === 'twitter:description') meta.description = match[2];
-      if(match[1] === 'og:image' || match[1] === 'twitter:image') meta.image = match[2];
-      if(match[1] === 'og:title' || match[1] === 'twitter:title') meta.title = match[2];
-      if(match[1] === 'og:url') meta.url = match[2];
+      if(match[1] === 'description' || match[1] === 'og:description' || match[1] === 'twitter:description') {
+        meta.description = he.decode(match[2]);
+      }
+      if(match[1] === 'og:image' || match[1] === 'twitter:image') {
+        meta.image = he.decode(match[2]);
+      }
+      if(match[1] === 'og:title' || match[1] === 'twitter:title') {
+        meta.title = he.decode(match[2]);
+      }
+      if(match[1] === 'og:url') {
+        meta.url = match[2];
+      }
     }
     return meta;
   };

--- a/meta-extractor.js
+++ b/meta-extractor.js
@@ -61,7 +61,7 @@ if (Meteor.isServer) {
         meta.title = he.decode(match[2]);
       }
       if(match[1] === 'og:url') {
-        meta.url = match[2];
+        meta.url = he.decode(match[2]);
       }
     }
     return meta;

--- a/package.js
+++ b/package.js
@@ -8,6 +8,9 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('0.9.0');
+  Npm.depends({
+    "he": "0.5.0"
+  });
   api.use(['http', 'check'], ['server']);
   api.addFiles('meta-extractor.js');
   api.export('extractMeta');


### PR DESCRIPTION
Some websites put HTML entities into their meta fields, I added `he` to decode them.

_See [this WIRED article](http://www.wired.com/2016/02/apple-fbi-privacy-security/) as an example:_

```
<meta name="twitter:title" content="Don&#039;t Be Misled. The Apple-FBI Fight Isn&#039;t About Privacy vs. Security" />
```
