### PR TITLE
revert es6

### DIFF
--- a/meta-extractor.js
+++ b/meta-extractor.js
@@ -12,16 +12,16 @@ if (Meteor.isClient) {
 }
 
 if (Meteor.isServer) {
-  let he = Npm.require('he');
+  var he = Npm.require('he');
 
   extractMeta = function (params) {
-    let html;
-    let match;
-    const META = {};
+    var html;
+    var match;
+    var META = {};
 
     if (params.substr(0, 4) === 'http') {
       try {
-        let result = HTTP.call('GET', params);
+        var result = HTTP.call('GET', params);
         if (result.statusCode !== 200) {
           return META;
         }
@@ -36,7 +36,7 @@ if (Meteor.isServer) {
 
 
     // search for a <title>
-    let title_regex = /<title>(.*)<\/title>/gmi;
+    var title_regex = /<title>(.*)<\/title>/gmi;
 
     while ((match = title_regex.exec(html)) !== null) {
       if (match.index === title_regex.lastIndex) {
@@ -46,9 +46,9 @@ if (Meteor.isServer) {
     }
 
     // search and parse all <meta>
-    let meta_tag_regex = /<meta.*?(?:name|property|http-equiv)=['"]([^'"]*?)['"][\w\W]*?content=['"]([^'"]*?)['"].*?>/gmi;
+    var meta_tag_regex = /<meta.*?(?:name|property|http-equiv)=['"]([^'"]*?)['"][\w\W]*?content=['"]([^'"]*?)['"].*?>/gmi;
 
-    let tags = {
+    var tags = {
       title: ['title', 'og:title', 'twitter:title'],
       description: ['description', 'og:description', 'twitter:description'],
       image: ['image', 'og:image', 'twitter:image'],
@@ -60,13 +60,13 @@ if (Meteor.isServer) {
         meta_tag_regex.lastIndex++;
       }
 
-      for (let item in tags) {
-        for (let possibleProperty of tags[item]) {
+      for (var item in tags) {
+        tags[item].forEach(function(prop) {
 
-          if (match[1] === possibleProperty) {
+          if (match[1] === prop) {
 
-            let property = tags[item][0];
-            let content = match[2];
+            var property = tags[item][0];
+            var content = match[2];
 
             // Only push content to our 'META' object if 'META' doesn't already
             // contain content for that property.
@@ -76,7 +76,7 @@ if (Meteor.isServer) {
 
           }
 
-        }
+        });
       }
     }
 


### PR DESCRIPTION
The es6 syntax introduced in my previous PR was causing issues. This commit reverts to older syntax/features without affecting functionality.
